### PR TITLE
new route for config vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,7 @@ Temporary Items
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+.idea
 
 # End of https://www.toptal.com/developers/gitignore/api/python,macos,vscode,flask
 

--- a/src/conf_vars.rs
+++ b/src/conf_vars.rs
@@ -1,24 +1,8 @@
 // imports for working with environment variables and .env files
 use dotenv::dotenv;
 use std::env;
+use crate::structures::ConfVars;
 
-// config structure
-#[derive(Clone)]
-pub struct ConfVars {
-    pub min_time: u32,
-    pub max_time: u32,
-    pub default_time: u32,
-    pub max_question_length: u32,
-    pub default_delete_time: u32,
-    pub db_password: String,
-    pub db_user: String,
-    pub db_port: String,
-    pub db_server: String,
-    pub db_database: String,
-    pub db_collection: String,
-    pub server_ip: String,
-    pub server_port: u32,
-}
 
 pub fn get_conf_vars() -> Result<ConfVars, std::num::ParseIntError> {
     // importing environment variables from .env file

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 // imports
 use crate::{
-    conf_vars::{get_conf_vars, ConfVars},
-    QuestionResult, SubmitQuestion,
+    conf_vars::get_conf_vars,
+    QuestionResult, SubmitQuestion, ConfVars
 };
 use crate::{UserError, UserErrorType};
 use bson::{oid::ObjectId, Document};

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -119,3 +119,13 @@ pub async fn get_answer(
     };
     Ok(web::Json(output))
 }
+
+pub async fn get_config(data: web::Data<AppState>) -> Result<impl Responder, UserError> {
+    let config: ServerConfig = ServerConfig{
+        min_time: data.config.min_time,
+        max_time: data.config.max_time,
+        default_time: data.config.default_time,
+        max_question_length: data.config.max_question_length,
+    };
+    Ok(web::Json(config))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,9 @@ pub async fn main() -> std::io::Result<()> {
         return Ok(());
     }
 
-    println!("Server successfully running...\nStop with \"CTRL + C\"...");
+    let server: String = format!("{}:{}", config.server_ip, config.server_port); 
+
+    println!("Server successfully running on {}...\nStop with \"CTRL + C\"...", server);
 
     // starting the server
     HttpServer::new(move || {
@@ -55,7 +57,7 @@ pub async fn main() -> std::io::Result<()> {
                     ),
             )
     })
-    .bind("127.0.0.1:8080")?
+    .bind(server)?
     .run()
     .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use crate::errors::{UserError, UserErrorType};
 use crate::handlers::*;
 use crate::structures::*;
 use actix_web::{web, App, HttpServer};
-use conf_vars::ConfVars;
 
 #[actix_web::main]
 pub async fn main() -> std::io::Result<()> {
@@ -45,7 +44,8 @@ pub async fn main() -> std::io::Result<()> {
                     .service(
                         web::scope("/get")
                             .route("/answer/{object_id}", web::get().to(get_answer))
-                            .route("/question", web::get().to(get_question)),
+                            .route("/question", web::get().to(get_question))
+                            .route("/config", web::get().to(get_config)),
                     )
                     .service(
                         web::scope("/submit")

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -1,4 +1,3 @@
-use crate::conf_vars;
 use mongodb::{bson, Collection};
 use serde::{Deserialize, Serialize};
 
@@ -42,5 +41,31 @@ pub struct GetAnswer {
 
 pub struct AppState {
     pub collection: Collection,
-    pub config: conf_vars::ConfVars,
+    pub config: ConfVars,
+}
+
+// config structure
+#[derive(Clone)]
+pub struct ConfVars {
+    pub min_time: u32,
+    pub max_time: u32,
+    pub default_time: u32,
+    pub max_question_length: u32,
+    pub default_delete_time: u32,
+    pub db_password: String,
+    pub db_user: String,
+    pub db_port: String,
+    pub db_server: String,
+    pub db_database: String,
+    pub db_collection: String,
+    pub server_ip: String,
+    pub server_port: u32,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct ServerConfig {
+    pub min_time: u32,
+    pub max_time: u32,
+    pub default_time: u32,
+    pub max_question_length: u32,
 }


### PR DESCRIPTION
added a new route which outputs the config vars of the server, such as min_time and max_question_length. This has the advantage that clients and interfaces can limit the possible selections to eliminate errors before they happen.